### PR TITLE
Remove details on switching to alt right click

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Changes I make to the Mac in settings to get it how I like it.
 - Untick `Group windows by application`. Should be able to more easily move between the windows of an app.
 - Set Dashboard as `As space`. This is what enables the sticky notes in the far left Space on a Mac.
 
-### System Preferences > Trackpad
-
-- In options for secondary click choose `Click in bottom right corner`
-
 ### System Preferences > Dock
 
 - Tick `Automatically hide and show the Dock`


### PR DESCRIPTION
Previously on a Mac I preferred to make clicking the bottom right of the track pad my default for right clicking. I found the trackpad just didn't capture me using 2 fingers reliable enough.

However I have since moved to a new MackBook pro with touchpad, which features a new version of the trackpad. It seems to be capturing when I want to right click using 2 fingers without issue, hence removing details about using the alternate method.