### PR TITLE
Add details on installing pyenv to manage python

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ General and base stuff will go here. App or tool specific stuff will have their 
 - [NVM](nvm.md)
 - [Rbenv](rbenv.md)
 - [Jenv](jenv.md)
+- [Pyenv](pyenv.md)
 - [Atom](atom.md)
 - [OpenVPN](openvpn.md)
 - [Firefox](firefox.md)

--- a/pyenv.md
+++ b/pyenv.md
@@ -1,0 +1,32 @@
+# Pyenv
+
+[Pyenv](https://github.com/pyenv/pyenv) is a version manager for Python.
+
+## Install
+
+```bash
+brew install pyenv
+pyenv init
+```
+
+`pyenv init` in my case outputted the following in my terminal
+
+```text
+# Load pyenv automatically by appending
+# the following to ~/.bash_profile:
+
+eval "$(pyenv init -)"
+```
+
+I actually add a slightly tweaked version to protect against errors should **pyenv** not be found
+
+```bash
+# To enable shims and autocompletion for pyenv
+if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi
+```
+
+If you want more details on what `pyenv init` actually does check out [Advanced Configuration](https://github.com/pyenv/pyenv#advanced-configuration).
+
+## Use
+
+Grab the latest version of [Python](https://www.python.org/) by first running `pyenv install -l` which will return a list of all available **Python** versions. Select the latest version 3 branch and then run `pyenv install 3.6.1`. Then run `pyenv global 3.6.1` to set it as you global default version, replacing the outdated system one.


### PR DESCRIPTION
When following the Docker tutorial it required me to use Python, which is on the mac by default, but also **pip** to install dependencies. That wasn't available.

So to keep things inline with how I have other languages setup I went looking for a Python version manager and found [Pyenv](https://github.com/pyenv/pyenv) to be the only player in town.

So this add details on installing **pyenv**, then a version of Python and setting it as the global default.

For reference having followed this process nothing more was needed to get [pip](https://en.wikipedia.org/wiki/Pip_(package_manager)) as it comes with all versions of Python since 2.9.