### PR TITLE
Update config details for vim to ident as I like

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -77,8 +77,19 @@ set wrap linebreak nolist
 " Set the default color to darkblue
 colo darkblue
 
-" Turn on filetype indentation detection
-filetype plugin indent on
+" Configure Vim to always use spaces for tabs, and to use 2 not 4
+" expandtab: Affects what happens when you press the <TAB> key.
+" If 'expandtab' is set, pressing the <TAB> key will always insert
+" 'softtabstop' amount of space characters
+" shiftwidth: affects what happens when you press >>, << or ==
+" softtabstop: affects what happens when you press the <TAB> or <BS> keys.
+" Its default value is the same as the value of 'tabstop', but when using
+" indentation without hard tabs or mixed indentation, you want to set it to
+" the same value as 'shiftwidth'
+" http://vim.wikia.com/wiki/Indenting_source_code 
+set expandtab
+set shiftwidth=2
+set softtabstop=2
 
 " Close vim if the only window left open is a NERD Tree
 autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif


### PR DESCRIPTION
Previously I had `filetype plugin indent on` in my `.vimrc` and thought it would sort out my indentation when working on files.

However when I still kept getting 4 spaces and weird indentation some further reading highlighted that it also expects you to have populated the folder `~/.vim/after/ftplugin` with configs for each type of file.

An example would be `python.vim`

```vim
setlocal expandtab
setlocal shiftwidth=4
setlocal softtabstop=4
```

So rather than mess with that I've instead opted to just use my preferred indentation as the default (always 2 spaces) and I can adjust manually depending on the file type I'm working on.