### PR TITLE
Add config settings to vim to stop backup files

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -77,6 +77,11 @@ set wrap linebreak nolist
 " Set the default color to darkblue
 colo darkblue
 
+" Do not create any temporary files when editing
+set nobackup
+set nowritebackup
+set noswapfile
+
 " Configure Vim to always use spaces for tabs, and to use 2 not 4
 " expandtab: Affects what happens when you press the <TAB> key.
 " If 'expandtab' is set, pressing the <TAB> key will always insert


### PR DESCRIPTION
Vim creates temporary files in your directory when editing a file to protect you from lost data should it crash before you can save.

However they often get left behind after you have completed your edits. Some folks advise leaving Vim do its thing and set your global git config to ignore them, but I recently got caught out by a vim file which was created, but which I hadn't included in my config (so ended up
committing).

I've decided I'm willing to take the risk (folks also seem to conclude if Vim is going to crash, it'll only be when editing over ssh or some such thing) so this change updates the config top tell vim not to create any temporary files.