### PR TITLE
Add a page to cover install and use of S3cmd tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ General and base stuff will go here. App or tool specific stuff will have their 
 - [Firefox](firefox.md)
 - [Gemrc](gemrc.md)
 - [VSCode](vscode.md)
+- [S3cmd tools](s3cmdtools.md)
 
 ## General
 

--- a/s3cmdtools.md
+++ b/s3cmdtools.md
@@ -1,0 +1,32 @@
+# S3cmd tools
+
+[S3cmd tools](http://s3tools.org/s3cmd) is a free command line tool and client for uploading, retrieving and managing data in Amazon S3 and other cloud storage service providers that use the S3 protocol, such as Google Cloud Storage or DreamHost DreamObjects.
+
+## Install
+
+```bash
+brew install s3cmd
+```
+
+## Use
+
+To authenticate with a bucket you'll need its access key and secret key. These will then need to be passed in as arguments each time you call **S3cmd**. To list what's in a bucket for example
+
+```bash
+s3cmd --access_key=UJUJUJU34344EDCOLM --secret_key=VBdsfjh875345MUTYguuiDC868689 ls s3://my-s3-bucket
+```
+
+To download a file
+
+```bash
+s3cmd --access_key=UJUJUJU34344EDCOLM --secret_key=VBdsfjh875345MUTYguuiDC868689 get s3://my-s3-bucket/name-of-file.tar.gz.enc
+```
+
+To upload a file
+
+```bash
+s3cmd --access_key=UJUJUJU34344EDCOLM --secret_key=VBdsfjh875345MUTYguuiDC868689 put myfile.tar.gz.enc s3://my-s3-bucket
+```
+
+For full details checkout <http://s3tools.org/usage>
+


### PR DESCRIPTION
A number of our digital services make use of AWS S3 buckets, plus its typically used as a mechanism for transfering files between production environments and the developers.

Because I wanted to capture the basic commands I use, as well as how to install it I've added a new page to cover this tool.