### PR TITLE
Update details on terminal package used for Atom

### DIFF
--- a/atom.md
+++ b/atom.md
@@ -113,11 +113,11 @@ Cucumber support for atom <https://atom.io/packages/cucumber>.
 apm install cucumber
 ```
 
-### Terminal-plus
+### PlatformIO IDE Terminal
 
-Add a terminal panel to Atom <https://atom.io/packages/terminal-plus>
+A terminal package for Atom, complete with themes, API and more for PlatformIO IDE. Fork of terminal-plus. <https://atom.io/packages/platformio-ide-terminal>
 
 ```bash
-apm install terminal-plus
+apm install platformio-ide-terminal
 ```
 


### PR DESCRIPTION
Have previously used terminal plus but for a long time it doesn't seem to be working and giving errors. Finally sorted it by switching to platformio-ide-terminal, so updating my documents to reflect this.