### PR TITLE
Add details on setup, config and howto git signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # Mac setup
 
-This repo simply serves as respository for how I setup various things on a Mac, in case of the time when I either change or it blows up!
+This repo simply serves as repository for how I setup various things on a Mac, in case of the time when I either change it or it blows up!
 
 General and base stuff will go here. App or tool specific stuff will have their own files.
 
-- [Git](git.md)
-- [Vim](vim.md)
-- [Terminal](terminal.md)
-- [NVM](nvm.md)
-- [Rbenv](rbenv.md)
-- [Jenv](jenv.md)
-- [Pyenv](pyenv.md)
 - [Atom](atom.md)
-- [OpenVPN](openvpn.md)
 - [Firefox](firefox.md)
 - [Gemrc](gemrc.md)
-- [VSCode](vscode.md)
+- [Git](git.md)
+- [GPG](gpg.md)
+- [Jenv](jenv.md)
+- [NVM](nvm.md)
+- [OpenVPN](openvpn.md)
+- [Pyenv](pyenv.md)
+- [Rbenv](rbenv.md)
 - [S3cmd tools](s3cmdtools.md)
+- [Terminal](terminal.md)
+- [Vim](vim.md)
+- [VSCode](vscode.md)
 
 ## General
 

--- a/git.md
+++ b/git.md
@@ -60,6 +60,21 @@ git config --global push.default simple
 git config --global fetch.prune true
 ```
 
+### Set GPG signing
+
+```bash
+git config --global user.signingkey [key ID]
+```
+
+See [GPG](gpg.md) and the 'Viewing keys' section on how to find the key ID.
+
+You must then add this to `.bash_profile`
+
+```bash
+# Needed to support signing of my git commits
+export GPG_TTY=$(tty)
+```
+
 ## Aliases
 
 ```bash
@@ -92,3 +107,12 @@ Some places have a habit when setting things up internally of not bothering with
 git config http.sslVerify false
 ```
 
+### Sign commits by default
+
+To manually sign a commit you call `git commit -S`. You can also set this as the default on a global or local level. I choose to go with local due to not all source code hosts supporting GPG signed commits.
+
+```bash
+git config commit.gpgsign true
+```
+
+You will be required to enter your key's passphrase after every commit, but the [GPG suite](https://gpgtools.org/) has tools that let you store your passphrase in the Mac OS keychain which removes this requirement. At this time I'm happy to just keep entering it.

--- a/gpg.md
+++ b/gpg.md
@@ -1,0 +1,66 @@
+# GPG
+
+[GnuPG]((https://www.gnupg.org/index.html) (also known as GPG) is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP). It is a command line tool with features for easy integration with other applications. It is used to encrypt and sign data, and features a key management system.
+
+As part of following GitHub's instructions on [signing commits with gpg](https://help.github.com/articles/signing-commits-with-gpg/), the first step is to install it.
+
+## Install
+
+```bash
+brew install gpg
+```
+
+## Generating a key
+
+I now have a generated key for use when signing my git commits. However should I need to generate another one in the future just call `gpg --full-generate-key`.
+
+Note, the GitHub instructions tell you to just call `gpg --gen-key` but not only does gpg say to use the full one, I just got issues until I switched to running through the full dialog.
+
+## Exporting existing keys
+
+To export my keys I basically followed these instructions on how to [back up your pgp keys with gpg](https://msol.io/blog/tech/back-up-your-pgp-keys-with-gpg/)
+
+```bash
+gpg --armor --export > pgp-public-keys.asc
+gpg --armor --export-secret-keys > pgp-private-keys.asc
+gpg --export-ownertrust > pgp-ownertrust.asc
+```
+
+Having created these files save them to your super secret place from which you can access them from another machine when required.
+
+## Importing
+
+To import download the files we saved earlier and then call the following
+
+```bash
+gpg --import pgp-public-keys.asc
+gpg --import pgp-private-keys.asc
+gpg --import-ownertrust pgp-ownertrust.asc
+```
+
+That's it!
+
+## Viewing keys
+
+When setting Git and GitHub up to use your key you'll often be asked to get the key ID.
+
+```bash
+gpg --list-secret-keys --keyid-format LONG
+```
+
+Running this will return something like this
+
+```bash
+$ gpg --list-secret-keys --keyid-format LONG
+/Users/hubot/.gnupg/secring.gpg
+------------------------------------
+sec   4096R/3AA5C34371567BD2 2016-03-10 [expires: 2017-03-10]
+uid                          Hubot
+ssb   4096R/42B317FD4BA89E7A 2016-03-10
+```
+
+They key ID in this example is **3AA5C34371567BD2**.
+
+## Signing commits
+
+Having done all this you can then tell git about the gpg key. [Git](git.md) covers how to do this.


### PR DESCRIPTION
These changes cover the need to install GPG in order to sign my git commits, along with details on creating and managing the key generated, and configuring git to use it, and how to sign my commits.