### PR TITLE
Add new aliases for git add and commit

### DIFF
--- a/git.md
+++ b/git.md
@@ -95,6 +95,12 @@ Add the following to `/.bash_profile` in order to enable quick commands that can
 alias gst='git status -s'
 # Alias for git branch. -a means show all branches, both local and remote
 alias gb='git branch -a'
+# Alias for git add . The period means add everything
+alias ga='git add .'
+# Alias for git commit. -v means display the diff under the commit message for reference
+alias gc='git commit -v'
+# Alias for git commit --amend. -v still means display the diff under the commit message for reference
+alias gca='git commit -v --amend'
 ```
 
 ## Local settings


### PR DESCRIPTION
With finding out recently about the ability to see the diff of my staged changes below the commit message, thought it was about time I alias my git add and commit commands rather than always typing them out fully.

This change adds the aliases I'll be using.