### PR TITLE
Remove line no's config from Vim settings

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -68,9 +68,6 @@ execute pathogen#infect()
 " Turn syntax highlighting on
 syntax on
 
-" Turn on line numbers
-set number
-
 " Set 'soft wrap' on i.e. don't break up words when wrapping
 set wrap linebreak nolist
 


### PR DESCRIPTION
Decided that actually it makes working in Vim easier if I don't display line numbers. So this change removes the setting to display them from the `~/.vimrc` file.