### PR TITLE
Update notes to highlight VSCode is main editor

### DIFF
--- a/atom.md
+++ b/atom.md
@@ -1,6 +1,8 @@
 # Atom
 
-[Atom](https://atom.io/) is a text editor where I generally do everything but **Node.js** (I use [VS Code](https://code.visualstudio.com/) for that).
+[Atom](https://atom.io/) used to be my main editor. Now I generally do everything in [VS Code](https://code.visualstudio.com/).
+
+⚠️ Keeping this as a reference but beware it might be quite stale information!
 
 ## Install
 

--- a/vscode.md
+++ b/vscode.md
@@ -1,6 +1,6 @@
 # VS Code
 
-[VS Code](https://code.visualstudio.com/) is a text editor where I generally do any **Node.js** work (I use [Atom](https://atom.io/) for everything else).
+[VS Code](https://code.visualstudio.com/) is my main editor for all work. I used to use [Atom](https://atom.io/) for everything bar Node.js but have switched to it being my one for reasons 😁 
 
 ## Install
 


### PR DESCRIPTION
A few months back I switched to using VSCode for all work including Ruby.

This is just updating my docs to reflect this.