### PR TITLE
Move homebrew to own page to include autoupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,8 @@ Changes I make to the Mac in settings to get it how I like it.
 
 ## Base installations
 
-Core stuff I install which also supports getting other things loaded and/or setup. To save time when doing these all in one go you can skip the `brew update` that happens with each `brew install`.
+Core stuff I install which also supports getting other things loaded and/or setup. All are installed using [Homebrew](/homebrew.md). So, go check that guide first then come back here!
 
-Just call `export HOMEBREW_NO_AUTO_UPDATE=1` in the terminal session you are using to run all your installs.
-
-- [Homebrew](https://brew.sh/) `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 - [Avast antivirus](https://www.avast.com/en-gb/index#mac) `brew install --cask avast-security`
 - [Google Chrome](https://www.google.com/chrome/index.html) `brew install --cask google-chrome`
 - [DBeaver](https://dbeaver.io/) `brew install --cask dbeaver-community`

--- a/homebrew.md
+++ b/homebrew.md
@@ -1,0 +1,55 @@
+# Homebrew
+
+[Homebrew](https://brew.sh/) describes itself as the "Missing Package Manager for macOS".
+
+Rather than install apps directly, either through downloads from the web or via the app store, it is more common on 'dev' machines to install and manage apps using a package manager like **brew** (think [Chocolatey](https://chocolatey.org/) for Windows).
+
+## Install
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+## Usage
+
+In the main, just Google `brew app-I-want-to-install` and you'll find the [formulae](https://formulae.brew.sh/) to use.
+
+In the main, the apps I install using this are what Homebrew terms [casks](https://docs.brew.sh/Manpage#terminology) (macOS native applications).
+
+```bash
+brew install --cask docker`
+```
+
+The rest are typically downloading shell scripts and running them, for example [pyenv](/pyenv.md). These are what Homebrew term **formula**.
+
+```bash
+brew install pyenv
+```
+
+To list what Homebrew has installed use `brew list`.
+
+## Skip update for new machines
+
+Whenever you run `brew install` it will run `brew update` automatically to ensure that Homebrew is on the latest version before attempting the install.
+
+When I come to setup a new machine, I'll be running `brew install` many times, so this step can slow things down considerably. You can skip it though by calling `export HOMEBREW_NO_AUTO_UPDATE=1` first, in the terminal session you are using to run all your installs.
+
+## Auto-update
+
+Some apps I install with have inbuilt auto-update functions. For the rest, and Homebrew itself it is on you to update it.
+
+In order to automate this I use [Homebrew Autoupdate](https://github.com/DomT4/homebrew-autoupdate).
+
+### Install
+
+```bash
+brew tap domt4/autoupdate
+```
+
+> a **tap** is a directory (and usually Git repository) of **formulae** and **casks**
+
+Then to enable auto-update call `brew autoupdate start 604800 --upgrade --cleanup`.
+
+- `604800` the number of seconds between updates. This represents a week
+- `--upgrade` also upgrade **casks** as well as Homebrew
+- `cleanup` clean Homebrew's cache and logs


### PR DESCRIPTION
Hit upon the ability to auto-update homebrew and the **casks** I install. So, there was now enough info to warrant moving Homebrew to its own guide.

Thanks to [Enabling Auto-updates in Homebrew](https://easyosx.net/2024/01/29/enabling-auto-updates-in-homebrew/) for the post that told me how to do it.